### PR TITLE
A: zilverengoudkopen.nl

### DIFF
--- a/easylistdutch/block_first_party_whitelist.txt
+++ b/easylistdutch/block_first_party_whitelist.txt
@@ -1,4 +1,6 @@
 @@||showmodeluitverkoop.nl/upload/advertentie/
 @@||te-les-koop.nl/advertenties.php
+@@||zilverengoudkopen.nl/banners/header
+@@||zilverengoudkopen.nl/banners/onder
 !
 @@||vinatera.be/wp-content/uploads/*_300x600.$image,~third-party


### PR DESCRIPTION
Because of the rule `||zilverengoudkopen.nl/banners/` in `easylistdutch/block_first_party_resource.txt` the banner at top and bottom of the site are also unnecessary blocked.

<details>
<summary>Screenshot 1</summary>

![image](https://user-images.githubusercontent.com/81161435/148238851-82749208-8cea-4bc2-95b9-1d58d32f61b7.png)

</details>

<details>
<summary>Screenshot 2</summary>

![image](https://user-images.githubusercontent.com/81161435/148238723-73e42544-a8e3-44dc-9e83-3a5d635b0b31.png)

</details>