### PR TITLE
placeholder on nd.nl

### DIFF
--- a/easylistdutch/hide_specific.txt
+++ b/easylistdutch/hide_specific.txt
@@ -264,6 +264,7 @@ menttv.be##.cta-container
 voetbaluitslagen.com##.cta__toplist
 kekmama.nl##.cts-row-wrapper
 touretappe.nl##.desktopad
+nd.nl##.desktoponly > .text-center
 ad.nl,bd.nl,bndestem.nl,destentor.nl,ed.nl,gelderlander.nl,goedgevoel.be,hln.be,pzc.nl,tubantia.nl##.dfp
 tpo.nl##.dus
 androidplanet.nl,iphoned.nl##.dynamic-content


### PR DESCRIPTION
could also be `nd.nl#?#.text-center:-abp-contains(advert)`, which I prefer.
fix #33