### PR TITLE
ijshockeynederland.nl as suggested in issue #49

### DIFF
--- a/easylistdutch/hide_specific.txt
+++ b/easylistdutch/hide_specific.txt
@@ -615,6 +615,7 @@ businessinsider.nl#?#.widget_custom_html:-abp-has(h2:-abp-contains(Beter Belegge
 geenstijl.nl#?#.article.row.no-image:-abp-has(.row.compost-warn:-abp-contains(- ingezonden mededeling -))
 gezondheidsnet.nl#?#.block-views:-abp-has(.view-gnet_gesponsorde_koppeling-display-block)
 hardware.info#?#:-abp-properties(content: "Advertentie";)
+ijshockeynederland.nl#?#div[class^="column col"]:-abp-has(img[src*="/uploads/ads"])
 indebuurt.nl#?#.list-item.list-item--aagje:-abp-has(.list-item__sponsor)
 investmentofficer.nl#?#.io-tape-card__wrap:-abp-has(.io-tape-card__label__sponsored)
 spaargids.be#?##latest_news_above:-abp-has(a[href^="https://www.deutschebank.be/"])


### PR DESCRIPTION
See #49 for more details. 

https://github.com/easylist/easylistdutch/issues/49#issuecomment-1119460531 

> > Filter suggestion: ijshockeynederland.nl##a[href="https://www.trexrubber.com/"][target="_blank"]
> 
> This only hides the element, but will cause a white gab in the row. 
> To fix that I propose `ijshockeynederland.nl#?#div[class^="column col"]:-abp-has(img[src*="/uploads/ads"])`

